### PR TITLE
Improve numeric input behaviour on mobile

### DIFF
--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -426,6 +426,30 @@ small {
   border: 1px solid var(--primary);
 }
 
+.btn-ghost {
+  background: rgba(17, 24, 39, 0.05);
+  color: var(--text);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+}
+
+.btn-ghost:hover {
+  opacity: 0.9;
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.btn-ghost:active {
+  transform: translateY(0);
+  opacity: 0.85;
+  box-shadow: none;
+}
+
+.keyboard-dismiss {
+  margin-left: auto;
+  flex: none;
+  white-space: nowrap;
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- replace native number inputs with sanitized text fields so iOS shows the Done button while keeping numeric validation
- tighten age question validation messaging using the shared numeric helpers
- upgrade the BMI calculator inputs with locale-aware parsing, range checks and a keyboard dismiss button, plus supporting styles

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68cecc2865ec8330a27a149f41523a52