### PR TITLE
Improve keyboard handling on mobile

### DIFF
--- a/frontend/scripts/layout.js
+++ b/frontend/scripts/layout.js
@@ -7,22 +7,77 @@
         return;
     }
 
-    const setAppHeight = () => {
+    const FOCUSABLE_SELECTOR = 'input, textarea, select, [contenteditable="true"]';
+    const KEYBOARD_THRESHOLD = 120; // px
+    let focusScrollTimeout = null;
+
+    const updateViewportMetrics = () => {
         const viewport = window.visualViewport;
         const height = viewport ? viewport.height : window.innerHeight;
-        if (!height) {
+        if (height) {
+            root.style.setProperty('--app-height', `${Math.round(height)}px`);
+        }
+
+        if (!viewport) {
+            root.style.setProperty('--keyboard-offset', '0px');
+            root.classList.remove('keyboard-open');
             return;
         }
-        root.style.setProperty('--app-height', `${Math.round(height)}px`);
+
+        const baseHeight = window.innerHeight || root.clientHeight;
+        const keyboardOffset = Math.max(0, baseHeight - viewport.height);
+        const isKeyboardOpen = keyboardOffset > KEYBOARD_THRESHOLD;
+
+        root.style.setProperty('--keyboard-offset', `${Math.round(keyboardOffset)}px`);
+        root.classList.toggle('keyboard-open', isKeyboardOpen);
+
+        if (isKeyboardOpen) {
+            const activeElement = document.activeElement;
+            if (activeElement instanceof HTMLElement && activeElement.matches(FOCUSABLE_SELECTOR)) {
+                scrollIntoView(activeElement);
+            }
+        }
     };
 
-    setAppHeight();
+    const scrollIntoView = (element) => {
+        if (!element || typeof element.scrollIntoView !== 'function') {
+            return;
+        }
 
-    window.addEventListener('resize', setAppHeight);
-    window.addEventListener('orientationchange', setAppHeight);
+        window.requestAnimationFrame(() => {
+            element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        });
+    };
+
+    const handleFocusIn = (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+
+        if (!target.matches(FOCUSABLE_SELECTOR)) {
+            return;
+        }
+
+        window.clearTimeout(focusScrollTimeout);
+        focusScrollTimeout = window.setTimeout(() => {
+            scrollIntoView(target);
+        }, 220);
+    };
+
+    const handleFocusOut = () => {
+        window.clearTimeout(focusScrollTimeout);
+    };
+
+    updateViewportMetrics();
+
+    window.addEventListener('resize', updateViewportMetrics);
+    window.addEventListener('orientationchange', updateViewportMetrics);
+    document.addEventListener('focusin', handleFocusIn, true);
+    document.addEventListener('focusout', handleFocusOut, true);
 
     if (window.visualViewport) {
-        window.visualViewport.addEventListener('resize', setAppHeight);
-        window.visualViewport.addEventListener('scroll', setAppHeight);
+        window.visualViewport.addEventListener('resize', updateViewportMetrics);
+        window.visualViewport.addEventListener('scroll', updateViewportMetrics);
     }
 })();

--- a/frontend/scripts/questions.js
+++ b/frontend/scripts/questions.js
@@ -59,7 +59,7 @@
     }
 
     function createNumericTextInput(options) {
-        const { allowDecimal, placeholder, enterKeyHint, onEnter } = options;
+        const { allowDecimal, placeholder, enterKeyHint = 'done', onEnter } = options;
 
         const input = document.createElement('input');
         input.type = 'text'; // Используем text вместо number для iOS
@@ -68,10 +68,17 @@
         input.spellcheck = false;
         input.autocapitalize = 'none';
         input.autocorrect = 'off';
-        input.inputMode = 'text'; // Показывает обычную текстовую клавиатуру
-        // Убрали pattern для iOS, чтобы не ограничивать ввод только цифрами
-        input.enterKeyHint = 'done'; // Показывает кнопку "Готово" на клавиатуре
-        
+        const inputMode = allowDecimal ? 'decimal' : 'numeric';
+        input.inputMode = inputMode;
+        input.setAttribute('inputmode', inputMode);
+        if (!allowDecimal) {
+            input.pattern = '\\d*';
+        }
+        if (enterKeyHint) {
+            input.enterKeyHint = enterKeyHint; // Показывает кнопку "Готово" на клавиатуре
+            input.setAttribute('enterkeyhint', enterKeyHint);
+        }
+
         if (placeholder) {
             input.placeholder = placeholder;
         }

--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -9,6 +9,7 @@
   --success: #2E8B57;
   --error: #D9534F;
   --app-height: 100dvh;
+  --keyboard-offset: 0px;
 
   --shadow-soft: 0 6px 18px rgba(20, 20, 20, 0.06);
   --shadow-sm: 0 2px 8px rgba(20, 20, 20, 0.04);
@@ -73,7 +74,7 @@ a:hover {
   align-items: stretch;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  scroll-padding-bottom: var(--space-6);
+  scroll-padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px));
 }
 
 .container {
@@ -84,9 +85,9 @@ a:hover {
   flex-direction: column;
   gap: var(--space-6);
   flex: 1;
-  padding-bottom: var(--space-6);
-  padding-bottom: calc(var(--space-6) + env(safe-area-inset-bottom));
-  padding-bottom: calc(var(--space-6) + constant(safe-area-inset-bottom));
+  padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px));
+  padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px) + env(safe-area-inset-bottom));
+  padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px) + constant(safe-area-inset-bottom));
 }
 
 .card {


### PR DESCRIPTION
## Summary
- detect virtual keyboard presence and keep inputs visible by scrolling the focused field into view
- extend layout spacing with a keyboard offset CSS variable so content stays above the keyboard on iOS
- request numeric keypads with native "Done" actions for height and weight inputs in the BMI calculator

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9600c38308330994bd7d7fd8b12e1