### PR TITLE
Improve mini-app viewport layout

### DIFF
--- a/frontend/questions.html
+++ b/frontend/questions.html
@@ -16,22 +16,26 @@
 <body>
     <main class="page">
         <div class="container" id="question-container">
-            <div class="progress">
-                <div class="progress__meta">
-                    <span class="progress__label" id="progress-label">Вопрос 1 из 21</span>
-                    <span class="progress__percent" id="progress-percent">0%</span>
+            <header class="page-header page-header--compact">
+                <div class="progress">
+                    <div class="progress__meta">
+                        <span class="progress__label" id="progress-label">Вопрос 1 из 21</span>
+                        <span class="progress__percent" id="progress-percent">0%</span>
+                    </div>
+                    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                        <div class="progress-fill" id="progress-fill" style="width: 0%"></div>
+                    </div>
                 </div>
-                <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                    <div class="progress-fill" id="progress-fill" style="width: 0%"></div>
-                </div>
-            </div>
+            </header>
 
-            <section class="card question-card" id="question-card">
-                <p class="question-card__meta" id="question-meta">Вопрос 1 из 21</p>
-                <h2 id="question-title"></h2>
-                <p class="muted" id="question-description"></p>
-                <div id="question-content" class="stack"></div>
-            </section>
+            <div class="content-scroll">
+                <section class="card question-card" id="question-card">
+                    <p class="question-card__meta" id="question-meta">Вопрос 1 из 21</p>
+                    <h2 id="question-title"></h2>
+                    <p class="muted" id="question-description"></p>
+                    <div id="question-content" class="stack"></div>
+                </section>
+            </div>
 
             <div class="navigation">
                 <button class="btn btn-secondary" type="button" id="back-button">Назад</button>
@@ -44,3 +48,4 @@
     <script src="scripts/questions.js?v=1.0.6"></script>
 </body>
 </html>
+

--- a/frontend/results.html
+++ b/frontend/results.html
@@ -17,40 +17,47 @@
 <body>
     <main class="page">
         <div class="container">
-            <section id="loading" class="card stack text-center loading-state">
-                <div class="spinner" aria-hidden="true"></div>
-                <h2>Анализируем ваши ответы...</h2>
-                <p class="muted">Подготавливаем персональные рекомендации</p>
-            </section>
+            <header class="page-header stack text-center">
+                <h2>Ваши результаты</h2>
+                <p class="muted">Мы подготовим персональные рекомендации за пару секунд</p>
+            </header>
 
-            <section id="results" class="hidden stack-lg">
-                <div class="card stack text-center">
-                    <h2>Ваши результаты</h2>
-                    <div class="result-number" id="life-expectancy">—</div>
-                    <p class="muted">лет ожидаемой продолжительности жизни</p>
-                    <p class="muted" id="result-delta"></p>
-                </div>
+            <div class="content-scroll">
+                <section id="loading" class="card stack text-center loading-state">
+                    <div class="spinner" aria-hidden="true"></div>
+                    <h2>Анализируем ваши ответы...</h2>
+                    <p class="muted">Подготавливаем персональные рекомендации</p>
+                </section>
 
-                <div class="card recommendations" id="insights-card">
-                    <h3>Сильные стороны</h3>
-                    <div id="insights-list" class="recommendation-list"></div>
-                </div>
+                <section id="results" class="hidden stack-lg">
+                    <div class="card stack text-center">
+                        <h3>Оценка продолжительности жизни</h3>
+                        <div class="result-number" id="life-expectancy">—</div>
+                        <p class="muted">лет ожидаемой продолжительности жизни</p>
+                        <p class="muted" id="result-delta"></p>
+                    </div>
 
-                <div class="card recommendations" id="recommendations-card">
-                    <h3>Что можно улучшить</h3>
-                    <div id="recommendations-list" class="recommendation-list"></div>
-                </div>
+                    <div class="card recommendations" id="insights-card">
+                        <h3>Сильные стороны</h3>
+                        <div id="insights-list" class="recommendation-list"></div>
+                    </div>
 
-                <div class="card" id="metrics-card">
-                    <h3>Ключевые показатели</h3>
-                    <dl class="metrics" id="metrics-list"></dl>
-                </div>
+                    <div class="card recommendations" id="recommendations-card">
+                        <h3>Что можно улучшить</h3>
+                        <div id="recommendations-list" class="recommendation-list"></div>
+                    </div>
 
-                <div class="navigation">
-                    <button class="btn btn-primary" type="button" id="restart-button">Пройти тест заново</button>
-                    <button class="btn btn-secondary" type="button" id="share-button">Поделиться результатом</button>
-                </div>
-            </section>
+                    <div class="card" id="metrics-card">
+                        <h3>Ключевые показатели</h3>
+                        <dl class="metrics" id="metrics-list"></dl>
+                    </div>
+                </section>
+            </div>
+
+            <div class="navigation">
+                <button class="btn btn-primary" type="button" id="restart-button">Пройти тест заново</button>
+                <button class="btn btn-secondary" type="button" id="share-button">Поделиться результатом</button>
+            </div>
         </div>
     </main>
 
@@ -58,3 +65,4 @@
     <script src="scripts/results.js?v=1.0.6"></script>
 </body>
 </html>
+

--- a/frontend/scripts/layout.js
+++ b/frontend/scripts/layout.js
@@ -11,6 +11,42 @@
     const KEYBOARD_THRESHOLD = 120; // px
     let focusScrollTimeout = null;
 
+    const ensureHexColor = (value) => {
+        if (typeof value !== 'string' || value.trim() === '') {
+            return null;
+        }
+        return value.startsWith('#') ? value : `#${value}`;
+    };
+
+    const applyTelegramTheme = () => {
+        const tg = window.Telegram?.WebApp;
+        if (!tg) {
+            return;
+        }
+
+        const params = tg.themeParams || {};
+        const colorMap = {
+            bg_color: '--bg',
+            secondary_bg_color: '--card',
+            text_color: '--text',
+            hint_color: '--muted',
+            button_color: '--primary',
+            link_color: '--accent',
+            button_text_color: '--button-text'
+        };
+
+        Object.entries(colorMap).forEach(([key, variable]) => {
+            const value = ensureHexColor(params[key]);
+            if (value) {
+                root.style.setProperty(variable, value);
+            }
+        });
+
+        if (typeof tg.colorScheme === 'string') {
+            root.dataset.colorScheme = tg.colorScheme;
+        }
+    };
+
     const updateViewportMetrics = () => {
         const viewport = window.visualViewport;
         const height = viewport ? viewport.height : window.innerHeight;
@@ -69,6 +105,7 @@
         window.clearTimeout(focusScrollTimeout);
     };
 
+    applyTelegramTheme();
     updateViewportMetrics();
 
     window.addEventListener('resize', updateViewportMetrics);
@@ -79,5 +116,11 @@
     if (window.visualViewport) {
         window.visualViewport.addEventListener('resize', updateViewportMetrics);
         window.visualViewport.addEventListener('scroll', updateViewportMetrics);
+    }
+
+    const tg = window.Telegram?.WebApp;
+    if (tg?.onEvent) {
+        tg.onEvent('themeChanged', applyTelegramTheme);
+        tg.onEvent('viewportChanged', updateViewportMetrics);
     }
 })();

--- a/frontend/styles/base.css
+++ b/frontend/styles/base.css
@@ -10,6 +10,7 @@
   --error: #D9534F;
   --app-height: 100dvh;
   --keyboard-offset: 0px;
+  --button-text: #ffffff;
 
   --shadow-soft: 0 6px 18px rgba(20, 20, 20, 0.06);
   --shadow-sm: 0 2px 8px rgba(20, 20, 20, 0.04);
@@ -43,6 +44,7 @@ html {
 
 body {
   margin: 0;
+  min-height: var(--app-height, 100vh);
   font-family: var(--font-body);
   background: var(--bg);
   color: var(--text);
@@ -65,16 +67,14 @@ a:hover {
 }
 
 .page {
-  min-height: 100vh;
   min-height: var(--app-height, 100vh);
   background: var(--bg);
-  padding: var(--space-6) var(--space-4);
+  padding: var(--space-5) var(--space-4);
   display: flex;
-  justify-content: center;
-  align-items: stretch;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  scroll-padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px));
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  overflow: hidden;
 }
 
 .container {
@@ -83,11 +83,47 @@ a:hover {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: var(--space-6);
+  gap: var(--space-5);
   flex: 1;
-  padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px));
-  padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px) + env(safe-area-inset-bottom));
-  padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px) + constant(safe-area-inset-bottom));
+  position: relative;
+  padding: var(--space-4);
+  padding-bottom: var(--space-4);
+}
+
+.content-scroll {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-right: 2px;
+  padding-bottom: calc(var(--space-7) + env(safe-area-inset-bottom));
+  scroll-padding-bottom: calc(var(--space-6) + var(--keyboard-offset, 0px));
+}
+
+.page-header {
+  position: sticky;
+  top: calc(env(safe-area-inset-top) + var(--space-2));
+  padding-top: env(safe-area-inset-top);
+  background: var(--bg);
+  z-index: 10;
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-4);
+  margin: calc(-1 * var(--space-4)) calc(-1 * var(--space-4)) var(--space-2);
+  box-shadow: 0 1px 0 rgba(17, 24, 39, 0.06);
+}
+
+.page-header .brand-logo,
+.page-header .subtitle,
+.page-header .version-info {
+  text-align: center;
+}
+
+.page-header--compact {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  box-shadow: none;
 }
 
 .card {
@@ -386,11 +422,17 @@ small {
   color: var(--error);
 }
 
+
 .navigation {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  margin-top: auto;
+  padding: var(--space-4) var(--space-4) calc(var(--space-4) + env(safe-area-inset-bottom));
+  background: var(--bg);
+  position: sticky;
+  bottom: 0;
+  z-index: 15;
+  box-shadow: 0 -6px 18px rgba(20, 20, 20, 0.08);
 }
 
 @media (min-width: 480px) {
@@ -418,7 +460,7 @@ small {
 
 .btn-primary {
   background: var(--primary);
-  color: #ffffff;
+  color: var(--button-text, #ffffff);
 }
 
 .btn-secondary {

--- a/frontend/welcome.html
+++ b/frontend/welcome.html
@@ -17,25 +17,27 @@
 <body>
     <main class="page">
         <div class="container">
-            <header class="stack text-center">
+            <header class="page-header stack text-center">
                 <span class="brand-logo">KamaLama BITE</span>
                 <p class="subtitle">Узнайте свою ожидаемую продолжительность жизни</p>
                 <p class="version-info">Версия: 1.0.6</p>
             </header>
 
-            <section class="card stack-lg text-center">
-                <h1>Быстрый тест о здоровье и привычках</h1>
-                <p class="muted">Ответьте на несколько вопросов и получите персональные рекомендации для улучшения качества жизни.</p>
-                <ul class="feature-list text-left">
-                    <li>Научно обоснованный расчет</li>
-                    <li>Проходит за 5 минут</li>
-                    <li>Данные не сохраняются</li>
-                    <li>Персональные рекомендации</li>
-                </ul>
-                <button class="btn btn-primary" onclick="startTest()">Начать тест</button>
-            </section>
+            <div class="content-scroll">
+                <section class="card stack-lg text-center">
+                    <h1>Быстрый тест о здоровье и привычках</h1>
+                    <p class="muted">Ответьте на несколько вопросов и получите персональные рекомендации для улучшения качества жизни.</p>
+                    <ul class="feature-list text-left">
+                        <li>Научно обоснованный расчет</li>
+                        <li>Проходит за 5 минут</li>
+                        <li>Данные не сохраняются</li>
+                        <li>Персональные рекомендации</li>
+                    </ul>
+                    <button class="btn btn-primary" onclick="startTest()">Начать тест</button>
+                </section>
 
-            <p class="legal">Ваши ответы обрабатываются анонимно и не сохраняются на серверах.</p>
+                <p class="legal">Ваши ответы обрабатываются анонимно и не сохраняются на серверах.</p>
+            </div>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- restructure the welcome, question, and results pages to keep headers and navigation fixed while scrolling only the main content
- refresh the shared layout styles with a dedicated scroll container, sticky navigation, and Telegram theme variable support
- extend the layout helper to react to Telegram theme updates for automatic color adaptation

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daa8a69fe083309164d021ac24b1c8